### PR TITLE
Adds addtional checks that should be made based off of discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # refinebio-processor-documentation
 For tracking documentation of the methodology behind our processor tests: https://github.com/AlexsLemonade/refinebio/issues/2470
 
+## New Required Tests
+
+In addition to improving the existing tests as listed in the links below, we also would like to run a few tests on a weekly basis to make sure things aren't drifting without us knowing.
+These can be configured to run as cron jobs on the foreman server.
+These should check:
+- that brainarray has not drastically changed genes since the last time it was run
+- that a newly generated QN reference file is similar enough to the latest version currently being used.
+
 ## Test Documentation Links
 
 ### [Array Express](./array_express.md)
@@ -20,4 +28,3 @@ For tracking documentation of the methodology behind our processor tests: https:
 ### [Smasher](./smasher.md)
 
 ### [Transcriptome Index](./transcriptome_index.md)
-

--- a/array_express.md
+++ b/array_express.md
@@ -64,4 +64,7 @@ It seems like it would be pretty easy to test `_create_ensg_pkg_map`, we just ha
 For `_determine_brainarray_package` we could test that `platform_accession_code` and `brainarray_package` are properly set in the job context.
 
 Also, right now we only check that the generated computed file exists and is named properly.
-We could improve the tests by checking that the generated computed file is generated properly by checking its correlation to a pre-computed file.
+We should improve the tests by checking that the generated computed file is generated properly by checking its correlation to a pre-computed file.
+This would involve:
+- Creating a reference PCL file and including it in the repo.
+- Checking that the gene expression column of the PCL file of both the generated and reference files had a Spearman correlation >= 0.99.

--- a/compendia.md
+++ b/compendia.md
@@ -52,7 +52,7 @@ test steps:
         - creates test Sample and associates it to the test Experiment and ComputationalResult
         - creates test ComputedFile and associates it to the test Sample
     - creates Sample with non-existent ComputedFile
-        - creates test Sample 
+        - creates test Sample
         - associates test Sample to the RNA-Seq Experiment and ComputationalResult
         - does not create a ComputedFile for this Sample
     - creates dataset using the Microarray and RNA-Seq Experiments created in previous steps
@@ -74,4 +74,12 @@ or it might make more sense to just test `smashing_utils.process_frames_for_key`
 
 Secondly, and most importantly we should definitely test the massive function `_perform_imputation`.
 Right now our tests just verify that the pipeline ran successfully and that the `compendium_result` exists.
-We should try to figure out a way to actually verify that the `compendium_result` looks the way it should.
+We should make sure that the intermediate tests work as well:
+- We should test that imputation is done correctly:
+    - Remove some values from the matrix.
+    - Run imputation.
+    - Compare the actual and imputed values.
+- We filter both rows and columns during creation of compendia, we should test that the expected rows and columns are dropped from the matrices. These filters are explained in the comments of the `create_compendia.py` processor file, but repeated here for convenience:
+    - Drop all rows in rnaseq_expression_matrix with a row sum < 10th percentile of rnaseq_row_sums; this is now filtered_rnaseq_matrix
+    - Remove samples (columns) with >50% missing values in combined_matrix
+- We should also test that quantile normalization is skipped for quantpendia.

--- a/geo.md
+++ b/geo.md
@@ -65,7 +65,7 @@ Tests the entire Agilent twocolor pipeline
 test steps:
 - prepares Agilent twocolor job
     - creates test ProcessorJob
-    - creates test OriginalFile 
+    - creates test OriginalFile
     - points the OriginalFile to an Agilent twocolor file
     - associates it to the test job
 - runs the Agilent twocolor pipeline
@@ -85,12 +85,17 @@ for `_detect_columns` we could test that `columnIds` are properly added to the j
 
 There are already tests that are meant to target `_detect_platform`, but it might be worth it to add some more targeted tests.
 
+We should improve the tests by checking that the generated computed files of both geo and illumina are generated properly by checking thier correlation to pre-computed files.
+This would involve:
+- Creating a reference file and including it in the repo.
+- Checking that the gene expression column of the file of both the generated and reference files had a Spearman correlation >= 0.99.
+
 When it comes to Agilent twocolor, it should be noted that as of right now we don't actually process any Agilent arrays in production
 because they are not in `config/supported_microarray_platforms.csv`.
 
 It might make sense to hold off on beefing up the Agilent twocolor tests until we support processing Agilent arrays in production.
 
 If we ever do decide to add tests for Agilent twocolor,
-the thing that stood out the most to me was the section in `_run_scan_twocolor` 
+the thing that stood out the most to me was the section in `_run_scan_twocolor`
 that refers to the expected bug that occurs in Biocunductor.
-It might be a good idea to look into this and see if that logic still stands. 
+It might be a good idea to look into this and see if that logic still stands.

--- a/no_op.md
+++ b/no_op.md
@@ -90,3 +90,8 @@ We could test that the ComputationalResult and the ComputedFile are properly cre
 
 More generally, submitter-processed data can be all over the place, so it would probably be a good idea to get more input files that are weird
 and test that they are handled correctly.
+
+We should improve the tests by checking that the generated computed file is generated properly by checking its correlation to a pre-computed file
+This would involve:
+- Creating a reference file and including it in the repo.
+- Checking that the gene expression column of the file of both the generated and reference files had a Spearman correlation >= 0.99.

--- a/transcriptome_index.md
+++ b/transcriptome_index.md
@@ -54,4 +54,7 @@ Additional functions like `_handle_shell_error` and `get_organism_name_from_path
 
 We could also add a RuntimeProcessor Test similar to the ones in `test_salmon.py` to validate that the `TX_INDEX` processor is set up correctly.
 
-
+The end to end tests should be updated to include a check to make sure that a file processed with salmon using a freshly generated transcriptome index are similar enough to a pre-computed files.
+This would involve:
+- Creating a reference quant.sf output file and including it in the repo.
+- the files are strongly correlated if both columns #3 and #4 (zero-indexed; TPM and NumReads) of the two files have a spearman correlation >= 0.99.


### PR DESCRIPTION
This adds the additional checks that @jaclyn-taroni and I discussed based off of what's already in this repo.

I will make additional issues in refinebio for renaming the array_express processor to affymetrix and no_op to gene_identifier_conversion.